### PR TITLE
Initial UVC support

### DIFF
--- a/electron-react-app/src/services/cameraConnection.ts
+++ b/electron-react-app/src/services/cameraConnection.ts
@@ -531,8 +531,8 @@ export function createUVCConnection({
         throw new Error('Canvas 2D context not available.');
       }
 
-      canvas.width = videoElement.videoWidth;
-      canvas.height = videoElement.videoHeight;
+      canvas.width = 240;
+      canvas.height = 240;
 
       // Set a filter for fixing the messed up contrast. Seems to be needed for the OpenIris cameras.
       ctx.filter = 'contrast(1.5)';
@@ -569,7 +569,7 @@ export function createUVCConnection({
         }
 
         // Pack and dispatch frame.
-        ctx?.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+        ctx?.drawImage(videoElement, 0, 0, 240, 240);
         const dataUrl = canvas.toDataURL('image/jpeg');
         store.dispatch(
           setCameraFrame({

--- a/electron-react-app/src/services/cameraConnection.ts
+++ b/electron-react-app/src/services/cameraConnection.ts
@@ -498,23 +498,6 @@ export function createUVCConnection({
 
       // Connect to the UVC device and setup the handler when the camera gets unplugged.
       videoStream = await navigator.mediaDevices.getUserMedia(constraints);
-      const videoTrack = videoStream.getVideoTracks()[0];
-      //console.log(videoTrack.getCapabilities());
-      //console.log(videoTrack.getConstraints());
-      //console.log(videoTrack.getSettings());
-      videoTrack.addEventListener('ended', () => {
-        console.error(`Camera on side ${side} has been disconnected.`);
-        store.dispatch(
-          setCameraFrame({
-            side,
-            frame: '',
-            timestamp: Date.now(),
-            status: 'offline',
-          })
-        );
-        onError?.(new Error('Camera disconnected'));
-        close();
-      });
 
       // Create the document elements and dump the data to the canvas.
       const videoElement = document.createElement('video');

--- a/electron-react-app/src/services/cameraConnection.ts
+++ b/electron-react-app/src/services/cameraConnection.ts
@@ -491,13 +491,17 @@ export function createUVCConnection({
 
       const constraints = {
         video: {
-          deviceId: { exact: deviceId }
+          deviceId: { exact: deviceId },
+          frameRate: { ideal: 60, max: 60 }
         }
       };
 
       // Connect to the UVC device and setup the handler when the camera gets unplugged.
       videoStream = await navigator.mediaDevices.getUserMedia(constraints);
       const videoTrack = videoStream.getVideoTracks()[0];
+      //console.log(videoTrack.getCapabilities());
+      //console.log(videoTrack.getConstraints());
+      //console.log(videoTrack.getSettings());
       videoTrack.addEventListener('ended', () => {
         console.error(`Camera on side ${side} has been disconnected.`);
         store.dispatch(

--- a/electron-react-app/src/services/cameraConnection.ts
+++ b/electron-react-app/src/services/cameraConnection.ts
@@ -389,3 +389,209 @@ export function createMJPEGCOMConnection(
     },
   };
 }
+
+/**
+ * Options for establishing a UVC-based connection.
+ */
+export interface UVCConnectionOptions {
+  side: 'leftEye' | 'rightEye';
+  index: number; // UVC index number, e.g., "3"
+  onError?: (error: any) => void;
+}
+
+/**
+ * Creates a single UVC connection to fetch, process, and dispatch camera frames.
+ *
+ * This function:
+ * - Gets all available UVC devices.
+ * - Initiates an UVC stream for the given index and continuously reads the stream.
+ * - Processes each frame by correcting the contrast as the default contrast seems to be wrong.
+ * - Dispatches the processed frame to update the camera status in the Redux store.
+ * - Implements a timeout mechanism to mark the camera as offline if no new frame is received.
+ * - Exposes a close method to allow external cancellation of the connection.
+ *
+ * @param options - Connection options including the UVC index, camera side, and an optional error callback.
+ * @returns An object with a `close` method to terminate the connection.
+ */
+export function createUVCConnection({
+  side,
+  index,
+  onError,
+}: UVCConnectionOptions): CameraConnection {
+  const cancelFlag = { cancelled: false };
+  
+  let videoStream: MediaStream | null = null;
+  let captureInterval: ReturnType<typeof setInterval> | null = null;
+  let offlineTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Closes the UVC connection.
+   *
+   * Marks the connection as cancelled, clears any pending timeouts,
+   * aborts the fetch, and cancels the stream reader.
+   */
+  function close() {
+    cancelFlag.cancelled = true;
+    if (captureInterval) {
+      clearInterval(captureInterval);
+      captureInterval = null;
+    }
+    if (offlineTimeout) {
+      clearTimeout(offlineTimeout);
+      offlineTimeout = null;
+    }
+    if (videoStream) {
+      videoStream.getTracks().forEach(track => track.stop());
+      videoStream = null;
+    }
+  }
+
+  /**
+   * Resets the offline timeout.
+   *
+   * If no new frame is received within the timeout period (currently 1000ms),
+   * the connection is marked offline, the store is updated, and the connection is closed.
+   */
+  function resetOfflineTimeout() {
+    if (offlineTimeout) clearTimeout(offlineTimeout);
+    offlineTimeout = setTimeout(() => {
+      if (!cancelFlag.cancelled) {
+        const currentState = store.getState();
+        const cameraData = currentState.status.imageData[side];
+        if (cameraData.status !== 'offline') {
+          store.dispatch(
+            setCameraFrame({
+              side,
+              frame: cameraData.frame,
+              timestamp: cameraData.timestamp || Date.now(),
+              status: 'offline',
+            })
+          );
+        }
+        close();
+        // Notify the creator that the connection is closing due to a stale frame.
+        if (onError) {
+          onError(new Error("Stale frame: connection closed due to no new frames"));
+        }
+      }
+    }, 1000);
+  }
+
+  // Main loop: fetch and parse the images.
+  (async () => {
+    try {
+
+      // Get all UVC devices and check if the right one was specified.
+      const allDevices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = allDevices.filter(d => d.kind === 'videoinput');
+      if (index < 0 || index >= videoDevices.length) {
+        throw new Error(`No camera found at index ${index}. Found ${videoDevices.length} video devices.`);
+      }
+      const deviceId = videoDevices[index].deviceId;
+
+      const constraints = {
+        video: {
+          deviceId: { exact: deviceId }
+        }
+      };
+
+      // Connect to the UVC device and setup the handler when the camera gets unplugged.
+      videoStream = await navigator.mediaDevices.getUserMedia(constraints);
+      const videoTrack = videoStream.getVideoTracks()[0];
+      videoTrack.addEventListener('ended', () => {
+        console.error(`Camera on side ${side} has been disconnected.`);
+        store.dispatch(
+          setCameraFrame({
+            side,
+            frame: '',
+            timestamp: Date.now(),
+            status: 'offline',
+          })
+        );
+        onError?.(new Error('Camera disconnected'));
+        close();
+      });
+
+      // Create the document elements and dump the data to the canvas.
+      const videoElement = document.createElement('video');
+      videoElement.srcObject = videoStream;
+      await videoElement.play();
+
+      resetOfflineTimeout();
+
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+
+      if (!ctx) {
+        console.error('Could not get canvas 2D context.');
+        throw new Error('Canvas 2D context not available.');
+      }
+
+      canvas.width = videoElement.videoWidth;
+      canvas.height = videoElement.videoHeight;
+
+      // Set a filter for fixing the messed up contrast. Seems to be needed for the OpenIris cameras.
+      ctx.filter = 'contrast(1.5)';
+
+      // Get original tracking rate.
+      const state = store.getState();
+      const {
+        trackingRate
+      } = state.config;
+      const trackingRateOld = trackingRate;
+
+      // Continuously capture the images.
+      captureInterval = setInterval(() => {
+        if (cancelFlag.cancelled) return;
+        if (!videoElement.videoWidth || !videoElement.videoHeight) return;
+
+        // Restart capture on tracking rate change.
+        const state = store.getState();
+        const {
+          trackingRate
+        } = state.config;
+        if (trackingRateOld != trackingRate) {
+          console.log('racking rate changed, restarting...');
+          store.dispatch(
+            setCameraFrame({
+              side,
+              frame: '',
+              timestamp: Date.now(),
+              status: 'offline',
+            })
+          );
+          onError?.(new Error('Tracking rate changed, restarting...'));
+          close();
+        }
+
+        // Pack and dispatch frame.
+        ctx?.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+        const dataUrl = canvas.toDataURL('image/jpeg');
+        store.dispatch(
+          setCameraFrame({
+            side,
+            frame: dataUrl,
+            timestamp: Date.now(),
+            status: 'online',
+          })
+        );
+
+        resetOfflineTimeout();
+      }, trackingRateOld);
+
+    } catch (error: any) {
+      console.error(`Error in UVC capture for ${side}:`, error);
+      store.dispatch(
+        setCameraFrame({
+          side,
+          frame: '',
+          timestamp: Date.now(),
+          status: 'offline',
+        })
+      );
+      onError?.(error);
+    }
+  })();
+
+  return { close };
+}

--- a/electron-react-app/src/utilities/validation.ts
+++ b/electron-react-app/src/utilities/validation.ts
@@ -38,18 +38,35 @@ export function isValidComPort(comPort: string): boolean {
 }
 
 /**
- * Determines whether a given string is a valid COM port, a valid IPv4:Port endpoint, or neither.
+ * Validates whether a given string conforms to a valid UVC index.
  *
- * It uses isValidComPort() for COM port validation and isValidIpPort() for IP:Port validation.
+ * The expected format is "<number>", where:
+ * - <number> is one or more digits.
+ *
+ * @param uvcIndex - The string to validate.
+ * @returns True if the string is a valid UVC index, false otherwise.
+ */
+export function isValidUvcIndex(uvcIndex: string): boolean {
+  const trimmed = uvcIndex.trim();
+  const regex = /^\d+$/;
+  return regex.test(trimmed);
+}
+
+/**
+ * Determines whether a given string is a valid COM port, a valid IPv4:Port endpoint, a valid UVC index, or neither.
+ *
+ * It uses isValidComPort() for COM port validation, isValidIpPort() for IP:Port validation, and isValidUvcIndex() for UVC index validation.
  *
  * @param input - The string to validate.
- * @returns "COM" if the string is a valid COM port, "IP" if it is a valid IPv4:Port, or "Neither" otherwise.
+ * @returns "COM" if the string is a valid COM port, "IP" if it is a valid IPv4:Port, "UVC" if the string is a valid UVC index, or "Neither" otherwise.
  */
-export function determinePortType(input: string): 'COM' | 'IP' | 'Neither' {
+export function determinePortType(input: string): 'COM' | 'IP' | 'UVC' | 'Neither' {
   if (isValidComPort(input)) {
     return 'COM';
   } else if (isValidIpPort(input)) {
     return 'IP';
+  } else if (isValidUvcIndex(input)) {
+    return 'UVC';
   }
   return 'Neither';
 }


### PR DESCRIPTION
I have done some work today to get initial UVC (webcam) support going. New under development version of EyeTrackVR's OpenIris firmware works as UVC, which helps mitigate issues with cameras freezing etc. So far seems to be working quite well. I tried to match how the handling was done previously with choosing the type of "port".

To connect to a UVC device (webcam), just enter its index. This is the order in which the camera appears in your PC. You can see the index of the camera by looking at the list of cameras in Discord for instance. This is the same behavior how EyeTrackVR's app currently handles this, so I tried to match it as users will be familiar with it. In future, if they can figure out how to change the name of the UVC devices, we could fetch them by name for instance. I will come back to this when this possibility becomes available.

Additionally, the Tracking Rate slider directly affects the speed of capturing the images from the UVCs. Changing it will restart the stream to update the interval.

![image](https://github.com/user-attachments/assets/f69c7c20-16cc-4b75-86c0-70ae6c2b9c6f)

